### PR TITLE
Waypoint updater

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -55,7 +55,6 @@ class TLDetector(object):
 
         self.state = TrafficLight.UNKNOWN
         self.last_state = TrafficLight.UNKNOWN
-        self.last_wp = -1
         self.state_count = 0
 
         rospy.spin()
@@ -67,12 +66,14 @@ class TLDetector(object):
         self.waypoints = waypoints.waypoints
         N = len(self.waypoints)
         # Waypoints are only loaded once so at boot find closest waypoint idx of each traffic light stop line
+
         for x, y in self.config['stop_line_positions']:
             ds = []
             [ds.append(math.sqrt((x-self.waypoints[i].pose.pose.position.x)**2 + (y-self.waypoints[i].pose.pose.position.y)**2)) for i in range(N)]
             best_idx = np.argmin(ds)
             self.tl_wp_idx.append(best_idx)
             self.tl_xy.append([x, y])
+
 
     def closest_cb(self, msg):
         self.pose_wp_idx = msg.data
@@ -81,9 +82,8 @@ class TLDetector(object):
         # of nearest stop line, waypoint closest to nearest stop line, and state of nearest light
         closest_tl_xy, light_wp, state = self.process_traffic_lights()
 
-        if state != TrafficLight.RED and state != TrafficLight.YELLOW:
+        if state == TrafficLight.GREEN:
             light_wp = -1
-            self.last_wp = light_wp
 
         # Publish nearest waypoint and x-y coords of stop line so waypoint updater can slow if necessary
         red_light_pub = Float32MultiArray()

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -6,6 +6,7 @@ import math
 
 from geometry_msgs.msg import Quaternion
 
+from std_msgs.msg import Float32
 from styx_msgs.msg import Lane, Waypoint
 
 import tf
@@ -21,6 +22,7 @@ class WaypointLoader(object):
         rospy.init_node('waypoint_loader', log_level=rospy.DEBUG)
 
         self.pub = rospy.Publisher('/base_waypoints', Lane, queue_size=1, latch=True)
+        self.target_v_pub = rospy.Publisher('/target_v', Float32, queue_size=1)
 
         self.velocity = self.kmph2mps(rospy.get_param('~velocity'))
         self.new_waypoint_loader(rospy.get_param('~path'))
@@ -77,6 +79,7 @@ class WaypointLoader(object):
         lane.header.stamp = rospy.Time(0)
         lane.waypoints = waypoints
         self.pub.publish(lane)
+        self.target_v_pub.publish(Float32(self.velocity))
 
 
 if __name__ == '__main__':

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -36,6 +36,7 @@ class WaypointUpdater(object):
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        rospy.Subscriber('/target_v', Float32, self.targetv_cb)
         rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
@@ -61,6 +62,7 @@ class WaypointUpdater(object):
         self.prev_idx = None
         # Ego's current velocity
         self.v = 0
+        self.TARGET_V = 0
 
         # Stop waypoint closest to nearest upcoming traffic light as published by tl_detector.py
         self.stop_waypoint = -1
@@ -162,8 +164,12 @@ class WaypointUpdater(object):
     def waypoints_cb(self, waypoints):
         rospy.loginfo("waypoints_cb is called")
         self.waypoints = waypoints.waypoints
-        self.TARGET_V = self.waypoints[0].twist.twist.linear.x
         self.handle_final_waypoints()
+
+    def targetv_cb(self, msg):
+        self.TARGET_V = msg.data
+        #unblock below to set TARGET_V manually here
+        #self.TARGET_V = 35*1609.34/60/60 # first number is mph followed by conversion to mps
 
     def velocity_cb(self, msg):
         rospy.loginfo("velocity_cb is called")
@@ -254,4 +260,3 @@ if __name__ == '__main__':
         WaypointUpdater()
     except rospy.ROSInterruptException:
         rospy.logerr('Could not start waypoint updater node.')
-        


### PR DESCRIPTION
# Pull Request Template

## Description
Fixed distance function that calculated 0 when ego was about to finish a lap around the track, i.e. between last and first stoplight. This caused ego to stop whenever the first traffic light turned red, even if the light wasn't close. Also, changed waypoint updater to reset every time there is a switch between autonomous and manual, allowing to backtrack manually and not lose waypoints. Finally, changed TARGET_V to be set by the launch file in waypoint loader. 

Fixes #7 

## How Has This Been Tested?
Performed a full loop around the track.

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published in downstream modules
