### PR TITLE
Optimize inference for single image

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_detector.py
+++ b/ros/src/tl_detector/light_classification/tl_detector.py
@@ -16,33 +16,33 @@ class TLDetector(object):
                 serialized_graph = fid.read()
                 od_graph_def.ParseFromString(serialized_graph)
                 tf.import_graph_def(od_graph_def, name='')
+        self.detection_session = tf.Session(graph=self.detection_graph)
+
+        # Get handles to input and output tensors
+        ops = self.detection_graph.get_operations()
+        all_tensor_names = {output.name for op in ops for output in op.outputs}
+        self.tensor_dict = {}
+        for key in [
+            'num_detections', 'detection_boxes', 'detection_scores', 'detection_classes'
+        ]:
+            tensor_name = key + ':0'
+            if tensor_name in all_tensor_names:
+                self.tensor_dict[key] = self.detection_graph.get_tensor_by_name(
+                        tensor_name)
+
+        self.image_tensor = self.detection_graph.get_tensor_by_name('image_tensor:0')
+
 
     def run_inference_for_single_image(self, image):
-        with self.detection_graph.as_default():
-            with tf.Session() as sess:
-                # Get handles to input and output tensors
-                ops = tf.get_default_graph().get_operations()
-                all_tensor_names = {output.name for op in ops for output in op.outputs}
-                tensor_dict = {}
-                for key in [
-                    'num_detections', 'detection_boxes', 'detection_scores', 'detection_classes'
-                ]:
-                    tensor_name = key + ':0'
-                    if tensor_name in all_tensor_names:
-                        tensor_dict[key] = tf.get_default_graph().get_tensor_by_name(
-                            tensor_name)
+        # Run inference
+        output_dict = self.detection_session.run(self.tensor_dict,
+                feed_dict={self.image_tensor: np.expand_dims(image, 0)})
 
-                image_tensor = tf.get_default_graph().get_tensor_by_name('image_tensor:0')
-
-                # Run inference
-                output_dict = sess.run(tensor_dict,
-                                       feed_dict={image_tensor: np.expand_dims(image, 0)})
-
-                # all outputs are float32 numpy arrays, so convert types as appropriate
-                output_dict['num_detections'] = int(output_dict['num_detections'][0])
-                output_dict['detection_classes'] = output_dict['detection_classes'][0].astype(np.uint8)
-                output_dict['detection_boxes'] = output_dict['detection_boxes'][0]
-                output_dict['detection_scores'] = output_dict['detection_scores'][0]
+        # all outputs are float32 numpy arrays, so convert types as appropriate
+        output_dict['num_detections'] = int(output_dict['num_detections'][0])
+        output_dict['detection_classes'] = output_dict['detection_classes'][0].astype(np.uint8)
+        output_dict['detection_boxes'] = output_dict['detection_boxes'][0]
+        output_dict['detection_scores'] = output_dict['detection_scores'][0]
         return output_dict
 
 


### PR DESCRIPTION
## Description

Some optimizations in run_inference_for_single_image

Fixes # (issue)
https://github.com/rioffe/CarND-Capstone-Solution/issues/14

## How Has This Been Tested?
- [ ] Run it from terminal: `python tl_detector.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules