### PR TITLE
call twist_controler.control even when dbw_enabled is false

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -108,13 +108,14 @@ class DBWNode(object):
             else:
                 self.prev_time = time.time()
 
+            throttle, brake, steer = self.controller.control(self.dbw_enabled,
+                                                             self.goal_linear_v,
+                                                             self.goal_angular_v,
+                                                             self.stop_a,
+                                                             self.current_linear_v,
+                                                             self.dt)
+
             if self.dbw_enabled:
-                throttle, brake, steer = self.controller.control(self.dbw_enabled,
-                                                                 self.goal_linear_v,
-                                                                 self.goal_angular_v,
-                                                                 self.stop_a,
-                                                                 self.current_linear_v,
-                                                                 self.dt)
                 self.publish(throttle, brake, steer)
 
             rate.sleep()


### PR DESCRIPTION
## Description

controller.control is never called if dbw_enabled is false.
As a result pid and filters are never reset.

## How Has This Been Tested?

- [x] Turn on/off manual mode in simulator and checked if controller.control is called.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules