### PR TITLE
Fix initialization order in order to avoid usage of uninitialized

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -30,6 +30,21 @@ class TLDetector(object):
         self.tl_wp_idx = [] # Waypoint indices of traffic lights
         self.tl_xy = [] # Stop line positions of traffic lights
 
+        config_string = rospy.get_param("/traffic_light_config")
+        self.config = yaml.load(config_string)
+
+        self.bridge = CvBridge()
+        self.use_simulator_classifier = rospy.get_param('~on_simulator')
+        rospy.loginfo("Is on simulator? %s" , self.use_simulator_classifier)
+        self.light_classifier = TLClassifier(isSimulator = self.use_simulator_classifier)
+        self.listener = tf.TransformListener()
+
+        self.state = TrafficLight.UNKNOWN
+        self.last_state = TrafficLight.UNKNOWN
+        self.state_count = 0
+
+        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Float32MultiArray, queue_size=1)
+
         sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
         # Add closest waypoint subscriber to receive current closest waypoint from waypoint WaypointUpdater
@@ -44,21 +59,6 @@ class TLDetector(object):
         '''
         sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
         sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)
-
-        config_string = rospy.get_param("/traffic_light_config")
-        self.config = yaml.load(config_string)
-
-        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Float32MultiArray, queue_size=1)
-
-        self.bridge = CvBridge()
-        self.use_simulator_classifier = rospy.get_param('~on_simulator')
-        rospy.loginfo("Is on simulator? %s" , self.use_simulator_classifier)
-        self.light_classifier = TLClassifier(isSimulator = self.use_simulator_classifier)
-        self.listener = tf.TransformListener()
-
-        self.state = TrafficLight.UNKNOWN
-        self.last_state = TrafficLight.UNKNOWN
-        self.state_count = 0
 
         rospy.spin()
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -34,26 +34,6 @@ class WaypointUpdater(object):
     def __init__(self):
         rospy.init_node('waypoint_updater')
 
-        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
-        rospy.Subscriber('/target_v', Float32, self.targetv_cb)
-        rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
-
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-        rospy.Subscriber('/traffic_waypoint', Float32MultiArray, self.traffic_cb)
-        #Add dbw enabled so closest waypoint finder can reset
-        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_cb)
-
-        # Publish closest waypoint so tl_dector.py doesn't have to repeat calculation
-        self.closest_waypoint_pub = rospy.Publisher('/closest_waypoint', Int32, queue_size=1)
-        self.final_waypoints_pub = rospy.Publisher('/final_waypoints', Lane, queue_size=1)
-
-        # If a red stop light has been detected within a distance based on current speed
-        # that allows enough time for a comfortable deceleration, then we publish it
-        # so that it doesn't have to be re-calculated in twist_controller.py, where it
-        # is used to calculate torque in Newton meters to control braking
-        self.stop_a_pub = rospy.Publisher('/stop_a', Float32, queue_size=1)
-
         # TODO: Add other member variables you need below
         self.vehicle_position = None
         self.vehicle_yaw = None
@@ -71,6 +51,26 @@ class WaypointUpdater(object):
         self.stop_y = -1
 
         self.dbw_enabled = False
+
+        # Publish closest waypoint so tl_dector.py doesn't have to repeat calculation
+        self.closest_waypoint_pub = rospy.Publisher('/closest_waypoint', Int32, queue_size=1)
+        self.final_waypoints_pub = rospy.Publisher('/final_waypoints', Lane, queue_size=1)
+
+        # If a red stop light has been detected within a distance based on current speed
+        # that allows enough time for a comfortable deceleration, then we publish it
+        # so that it doesn't have to be re-calculated in twist_controller.py, where it
+        # is used to calculate torque in Newton meters to control braking
+        self.stop_a_pub = rospy.Publisher('/stop_a', Float32, queue_size=1)
+
+        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
+        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        rospy.Subscriber('/target_v', Float32, self.targetv_cb)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
+
+        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
+        rospy.Subscriber('/traffic_waypoint', Float32MultiArray, self.traffic_cb)
+        #Add dbw enabled so closest waypoint finder can reset
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_cb)
 
         rospy.spin()
 


### PR DESCRIPTION
## Description

According to assumption that rospy callbacks are called by separate thread, fixed initialization order in order to avoid race during initialization.

Fixes # (issue)

Did not try it yet.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules